### PR TITLE
Add app and space name to auth metadata

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -554,6 +554,15 @@ func (e *Env) Login(t *testing.T) {
 	if resp.Auth.Alias.Metadata["space_id"] != cf.FoundSpaceGUID {
 		t.Fatalf("expected %s but received %s", cf.FoundSpaceGUID, resp.Auth.Alias.Metadata["space_id"])
 	}
+	if resp.Auth.Alias.Metadata["org_name"] != cf.FoundOrgName {
+		t.Fatalf("expected %s but received %s", cf.FoundOrgName, resp.Auth.Alias.Metadata["org_name"])
+	}
+	if resp.Auth.Alias.Metadata["app_name"] != cf.FoundAppName {
+		t.Fatalf("expected %s but received %s", cf.FoundAppName, resp.Auth.Alias.Metadata["app_name"])
+	}
+	if resp.Auth.Alias.Metadata["space_name"] != cf.FoundSpaceName {
+		t.Fatalf("expected %s but received %s", cf.FoundSpaceName, resp.Auth.Alias.Metadata["space_name"])
+	}
 	if resp.Auth.InternalData["ip_addresses"] != nil {
 		t.Fatalf("expected %s but received %s", "", resp.Auth.InternalData["ip_addresses"])
 	}

--- a/testing/cf/mock.go
+++ b/testing/cf/mock.go
@@ -17,6 +17,9 @@ const (
 	FoundAppGUID     = "2d3e834a-3a25-4591-974c-fa5626d5d0a1"
 	FoundOrgGUID     = "34a878d0-c2f9-4521-ba73-a9f664e82c7bf"
 	FoundSpaceGUID   = "3d2eba6b-ef19-44d5-91dd-1975b0db5cc9"
+	FoundAppName     = "name-2401"
+	FoundSpaceName   = "cfdev-space"
+	FoundOrgName     = "system"
 
 	UnfoundServiceGUID = "service-id-unfound"
 	UnfoundAppGUID     = "app-id-unfound"


### PR DESCRIPTION
# Overview
This adds `org_name`, `app_name` and `space_name` as items in Auth.Alias.Metadata.
```
As a user using Auth.Alias.Metadata in ACLs and performing blue-green deployments,
I do not want to change my secrets path if the app GUID changes. 
```
This has come out of discussions with our tenants. See [Issue #36](https://github.com/hashicorp/vault/issues/36) for more details.

Using names in ACL paths also eases to identify the context of a secret. There is a potential to lose access to secrets if an org, app, or space are renamed, this can however be mitigated by including moving of secrets in a renaming workflow.

It is a simple addition of three metadata items which does not impact current functionality.

We also add testing of the functionality to the backend tests.

# Design of Change
Implementing two functions `getAppName` and `getSpaceName` to be called after `validate` in `OperationLoginUpdate`.
Both functions create a new Cloud Foundry client and return the name from an `AppByGuid` and `GetSpaceByGuid` request, respectively. This is ~wordy, but keeps things clean.

# Related Issues/Pull Requests
- [x] [Issue #36](https://github.com/hashicorp/vault/issues/36)

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
The current metadata items are not documented outside of the code. We are happy to add to the docs, but did not find an obvious place to do so.
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
There is no additional test output. Added to backend tests
- [x] Backwards compatible
